### PR TITLE
Call cohere models with preamble argument, not user turn

### DIFF
--- a/models/cohere.py
+++ b/models/cohere.py
@@ -23,15 +23,15 @@ class CohereModel(BaseModel):
         """Execute request using the Cohere API"""
         try:
             # Combine system prompt and user prompt
-            full_prompt = f"{system_prompt}\n\n{formatted_prompt}"
             print(f"Making Cohere API request with model {self.model_name}...")
             response = self.client.chat(
                 model=self.model_name,
-                message=full_prompt,
+                preamble=system_prompt,
+                message=formatted_prompt,
                 temperature=0.5,
                 chat_history=[],
                 max_tokens=1000,
-                prompt_truncation='AUTO'
+                prompt_truncation='AUTO',
             )
             print("Received response from Cohere API")
             

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,10 @@ beautifulsoup4>=4.9.3
 # Model-specific dependencies
 openai>=1.0.0
 anthropic>=0.3.0
-cohere-ai>=4.0.0
+cohere>=4.0.0
 groq>=0.3.0
 boto3>=1.26.0
+google-generativeai
 
 # Azure OpenAI
 azure-openai>=1.0.0


### PR DESCRIPTION
Hey @peytoncasper ! Noticed in your tests of cohere models, you were calling with the system prompt added at the start of the user turn. For other model providers (e.g. Anthropic), I see you use the system argument as they describe - doing the same with Cohere's models (described in docs [here](https://docs.cohere.com/v1/docs/preambles)) improves performance from your reported ~78% to 87.2%.


Rerunning your tests: `python compare_models.py --model command-r7b-12-2024` I get output:

```
=== Overall Results ===

command-r7b-12-2024:
Average Score: 0.872
Total Cost: $0.032153
Average Latency: 12.694s
Easy Score: 0.991
Easy Latency: 7.210s
Medium Score: 0.755
Medium Latency: 9.487s
Hard Score: 0.787
Hard Latency: 30.836s
```